### PR TITLE
[Design] Moving to 3-columns cards for connector selection

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.scss
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.scss
@@ -1,4 +1,0 @@
-.actConnectorsListGrid {
-  padding-left: $euiSize * 4;
-  padding-right: $euiSize * 4;
-}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
@@ -11,7 +11,6 @@ import { loadActionTypes } from '../../lib/action_connector_api';
 import { useActionsConnectorsContext } from '../../context/actions_connectors_context';
 import { actionTypeCompare } from '../../lib/action_type_compare';
 import { checkActionTypeEnabled } from '../../lib/check_action_type_enabled';
-import './action_type_menu.scss';
 
 interface Props {
   onActionTypeChange: (actionType: ActionType) => void;
@@ -76,7 +75,7 @@ export const ActionTypeMenu = ({
       const card = (
         <EuiCard
           data-test-subj={`${item.actionType.id}-card`}
-          icon={<EuiIcon size="xl" type={item.iconClass} />}
+          icon={<EuiIcon size="l" type={item.iconClass} />}
           title={item.name}
           description={item.selectMessage}
           isDisabled={!checkEnabledResult.isEnabled}
@@ -101,7 +100,7 @@ export const ActionTypeMenu = ({
   return (
     <div className="actConnectorsListGrid">
       <EuiSpacer size="s" />
-      <EuiFlexGrid gutterSize="xl" columns={2}>
+      <EuiFlexGrid gutterSize="xl" columns={3}>
         {cardNodes}
       </EuiFlexGrid>
     </div>


### PR DESCRIPTION
## Summary

This PR reduces the size of cards (and the icons on them) in the "Select a Connector" flyout which @mdefazio and I thought they were still too big. See the updated view below

Before:

![image](https://user-images.githubusercontent.com/4016496/76803986-5fe8be80-6798-11ea-9e35-f7b97603be42.png)

After:

![image](https://user-images.githubusercontent.com/4016496/76803971-53646600-6798-11ea-96a6-4a71fbdf76f1.png)

![image](https://user-images.githubusercontent.com/4016496/76804091-ad652b80-6798-11ea-8080-0bc4e7f4f5e7.png)



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
