### PR TITLE
More design cleanups

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/check_action_type_enabled.scss
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/check_action_type_enabled.scss
@@ -1,3 +1,9 @@
 .actCheckActionTypeEnabled__disabledActionWarningCard {
   background-color: $euiColorLightestShade;
 }
+
+.actAccordionActionForm {
+  .euiCard {
+    box-shadow: none;
+  }
+}

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/check_action_type_enabled.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/check_action_type_enabled.tsx
@@ -39,6 +39,7 @@ export function checkActionTypeEnabled(
       ),
       messageCard: (
         <EuiCard
+          titleSize="xs"
           title={i18n.translate(
             'xpack.triggersActionsUI.sections.alertForm.actionTypeDisabledByLicenseMessageTitle',
             {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.scss
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.scss
@@ -1,5 +1,0 @@
-.actActionForm__disabledActionWarningTitle {
-  @include euiFontSizeS;
-  color: $euiColorDanger;
-  margin-left: $euiSizeS;
-}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
@@ -263,8 +263,8 @@ export const ActionForm = ({
         initialIsOpen={true}
         key={index}
         id={index.toString()}
-        className="euiAccordionForm"
-        buttonContentClassName="euiAccordionForm__button"
+        className="actAccordionActionForm"
+        buttonContentClassName="actAccordionActionForm__button"
         data-test-subj={`alertActionAccordion-${defaultActionGroupId}`}
         buttonContent={
           <EuiFlexGroup gutterSize="s" alignItems="center">
@@ -549,7 +549,6 @@ export const ActionForm = ({
                       target="_blank"
                       className="actActionForm__getMoreActionsLink"
                     >
-                      <EuiIcon type="starEmptySpace" />
                       <FormattedMessage
                         defaultMessage="Get more actions"
                         id="xpack.triggersActionsUI.sections.actionForm.getMoreActionsTitle"

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
@@ -301,7 +301,7 @@ export const ActionForm = ({
           <EuiButtonIcon
             iconType="cross"
             color="danger"
-            className="euiAccordionForm__extraAction"
+            className="actAccordionActionForm__extraAction"
             aria-label={i18n.translate(
               'xpack.triggersActionsUI.sections.alertForm.accordion.deleteIconAriaLabel',
               {
@@ -338,8 +338,8 @@ export const ActionForm = ({
         initialIsOpen={true}
         key={index}
         id={index.toString()}
-        className="euiAccordionForm"
-        buttonContentClassName="euiAccordionForm__button"
+        className="actAccordionActionForm"
+        buttonContentClassName="actAccordionActionForm__button"
         data-test-subj={`alertActionAccordion-${defaultActionGroupId}`}
         buttonContent={
           <EuiFlexGroup gutterSize="s" alignItems="center">
@@ -365,7 +365,7 @@ export const ActionForm = ({
           <EuiButtonIcon
             iconType="cross"
             color="danger"
-            className="euiAccordionForm__extraAction"
+            className="actAccordionActionForm__extraAction"
             aria-label={i18n.translate(
               'xpack.triggersActionsUI.sections.alertForm.accordion.deleteIconAriaLabel',
               {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
@@ -22,6 +22,7 @@ import {
   EuiEmptyPrompt,
   EuiButtonEmpty,
   EuiToolTip,
+  EuiIconTip,
   EuiLink,
 } from '@elastic/eui';
 import { HttpSetup, ToastsApi } from 'kibana/public';
@@ -40,7 +41,6 @@ import { TypeRegistry } from '../../type_registry';
 import { actionTypeCompare } from '../../lib/action_type_compare';
 import { checkActionTypeEnabled } from '../../lib/check_action_type_enabled';
 import { VIEW_LICENSE_OPTIONS_LINK } from '../../../common/constants';
-import './action_form.scss';
 
 interface ActionAccordionFormProps {
   actions: AlertAction[];
@@ -274,24 +274,35 @@ export const ActionForm = ({
             <EuiFlexItem>
               <EuiTitle size="s">
                 <h5>
-                  <FormattedMessage
-                    defaultMessage="Action: {actionConnectorName}"
-                    id="xpack.triggersActionsUI.sections.alertForm.selectAlertActionTypeEditTitle"
-                    values={{
-                      actionConnectorName: actionConnector.name,
-                    }}
-                  />
-                  {checkEnabledResult.isEnabled === false && (
-                    <Fragment>
-                      <span className="actActionForm__disabledActionWarningTitle">
-                        <EuiIcon type="alert" />
-                        <FormattedMessage
-                          defaultMessage="This action is disabled"
-                          id="xpack.triggersActionsUI.sections.alertForm.actionDisabledTitle"
-                        />
-                      </span>
-                    </Fragment>
-                  )}
+                  <EuiFlexGroup gutterSize="s">
+                    <EuiFlexItem grow={false}>
+                      <FormattedMessage
+                        defaultMessage="Action: {actionConnectorName}"
+                        id="xpack.triggersActionsUI.sections.alertForm.selectAlertActionTypeEditTitle"
+                        values={{
+                          actionConnectorName: actionConnector.name,
+                        }}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      {checkEnabledResult.isEnabled === false && (
+                        <Fragment>
+                          <EuiIconTip
+                            type="alert"
+                            color="danger"
+                            label="Beta"
+                            content={i18n.translate(
+                              'xpack.triggersActionsUI.sections.alertForm.actionDisabledTitle',
+                              {
+                                defaultMessage: 'This action is disabled',
+                              }
+                            )}
+                            position="right"
+                          />
+                        </Fragment>
+                      )}
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
                 </h5>
               </EuiTitle>
             </EuiFlexItem>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
@@ -74,6 +74,7 @@ export const ActionTypeMenu = ({
       const checkEnabledResult = checkActionTypeEnabled(item.actionType);
       const card = (
         <EuiCard
+          titleSize="xs"
           data-test-subj={`${item.actionType.id}-card`}
           icon={<EuiIcon size="l" type={item.iconClass} />}
           title={item.name}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_flyout.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_flyout.tsx
@@ -271,7 +271,6 @@ const upgradeYourLicenseCallOut = (
       'xpack.triggersActionsUI.sections.actionConnectorAdd.upgradeYourPlanBannerTitle',
       { defaultMessage: 'Upgrade your plan to access more connector types' }
     )}
-    iconType="starEmptySpace"
   >
     <FormattedMessage
       id="xpack.triggersActionsUI.sections.actionConnectorAdd.upgradeYourPlanBannerMessage"

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
@@ -15,7 +15,7 @@ import {
   EuiTitle,
   EuiLink,
   EuiLoadingSpinner,
-  EuiToolTip,
+  EuiIconTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -159,12 +159,14 @@ export const ActionsConnectorsList: React.FunctionComponent = () => {
         return checkEnabledResult.isEnabled ? (
           link
         ) : (
-          <EuiToolTip position="top" content={checkEnabledResult.message}>
-            <Fragment>
-              {link}
-              <EuiIcon type="questionInCircle" />
-            </Fragment>
-          </EuiToolTip>
+          <Fragment>
+            {link}
+            <EuiIconTip
+              type="questionInCircle"
+              content={checkEnabledResult.message}
+              position="right"
+            />
+          </Fragment>
         );
       },
     },

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_form/alert_edit.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_form/alert_edit.tsx
@@ -147,6 +147,7 @@ export const AlertEdit = ({
           {hasActionsDisabled && (
             <Fragment>
               <EuiCallOut
+                size="s"
                 color="danger"
                 iconType="alert"
                 title={i18n.translate(


### PR DESCRIPTION
## Summary

- Replaced Tooltip with IconTip where possible
- Added some improvements to the "Edit Alert" and "Add Connector" flyouts
- Removed the use of a star to indicate "upgrades" as discussed with DeFazio

![image](https://user-images.githubusercontent.com/4016496/76999782-7156d580-6914-11ea-960d-0cce7f78dc10.png)
![image](https://user-images.githubusercontent.com/4016496/76999806-7c116a80-6914-11ea-8d05-1b84800adedd.png)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
